### PR TITLE
Fixes, modification and addition of tests and validation of ManyToMany management

### DIFF
--- a/src/JHipsterNetSampleApplication/Controllers/BankAccountController.cs
+++ b/src/JHipsterNetSampleApplication/Controllers/BankAccountController.cs
@@ -55,6 +55,10 @@ namespace JHipsterNetSampleApplication.Controllers {
             if (bankAccount.Id == 0) throw new BadRequestAlertException("Invalid Id", EntityName, "idnull");
             //TODO catch //DbUpdateConcurrencyException into problem
             _applicationDatabaseContext.Update(bankAccount);
+            /* Force the reference navigation property to be in "modified" state.
+               This allows to modify it with a null value (the field is nullable).
+               This takes into consideration the case of removing the association between the two instances. */
+            _applicationDatabaseContext.Entry(bankAccount).Reference(bA => bA.User).IsModified = true;
             await _applicationDatabaseContext.SaveChangesAsync();
             return Ok(bankAccount)
                 .WithHeaders(HeaderUtil.CreateEntityUpdateAlert(EntityName, bankAccount.Id.ToString()));

--- a/src/JHipsterNetSampleApplication/Controllers/OperationController.cs
+++ b/src/JHipsterNetSampleApplication/Controllers/OperationController.cs
@@ -55,6 +55,10 @@ namespace JHipsterNetSampleApplication.Controllers {
             //TODO catch //DbUpdateConcurrencyException into problem
             _applicationDatabaseContext.OperationLabels.RemoveNavigationProperty(operation, operation.Id);
             _applicationDatabaseContext.Update(operation);
+            /* Force the reference navigation property to be in "modified" state.
+               This allows to modify it with a null value (the field is nullable).
+               This takes into consideration the case of removing the association between the two instances. */
+            _applicationDatabaseContext.Entry(operation).Reference(o => o.BankAccount).IsModified = true;
             await _applicationDatabaseContext.SaveChangesAsync();
             return Ok(operation).WithHeaders(HeaderUtil.CreateEntityUpdateAlert(EntityName, operation.Id.ToString()));
         }

--- a/test/JHipsterNetSampleApplication.Test/Web/Rest/BankAccountResourceIntTest.cs
+++ b/test/JHipsterNetSampleApplication.Test/Web/Rest/BankAccountResourceIntTest.cs
@@ -216,7 +216,7 @@ namespace JHipsterNetSampleApplication.Test.Web.Rest {
             var updatedBankAccount =
                 await _applicationDatabaseContext.BankAccounts.SingleOrDefaultAsync(it => it.Id == _bankAccount.Id);
             // Disconnect from session so that the updates on updatedBankAccount are not directly saved in db
-            //TODO detach
+//TODO detach
             updatedBankAccount.Name = UpdatedName;
             updatedBankAccount.Balance = UpdatedBalance;
 
@@ -251,7 +251,7 @@ namespace JHipsterNetSampleApplication.Test.Web.Rest {
             var updatedBankAccount = await _applicationDatabaseContext.BankAccounts
                 .SingleOrDefaultAsync(it => it.Id == _bankAccount.Id);
             // Disconnect from session so that the updates on updatedBankAccount are not directly saved in db
-            //TODO detach
+//TODO detach
             updatedBankAccount.Name = UpdatedName;
             updatedBankAccount.Balance = UpdatedBalance;
             updatedBankAccount.User = updatedUser;

--- a/test/JHipsterNetSampleApplication.Test/Web/Rest/BankAccountResourceIntTest.cs
+++ b/test/JHipsterNetSampleApplication.Test/Web/Rest/BankAccountResourceIntTest.cs
@@ -216,7 +216,7 @@ namespace JHipsterNetSampleApplication.Test.Web.Rest {
             var updatedBankAccount =
                 await _applicationDatabaseContext.BankAccounts.SingleOrDefaultAsync(it => it.Id == _bankAccount.Id);
             // Disconnect from session so that the updates on updatedBankAccount are not directly saved in db
-//TODO detach
+            //TODO detach
             updatedBankAccount.Name = UpdatedName;
             updatedBankAccount.Balance = UpdatedBalance;
 
@@ -251,7 +251,7 @@ namespace JHipsterNetSampleApplication.Test.Web.Rest {
             var updatedBankAccount = await _applicationDatabaseContext.BankAccounts
                 .SingleOrDefaultAsync(it => it.Id == _bankAccount.Id);
             // Disconnect from session so that the updates on updatedBankAccount are not directly saved in db
-//TODO detach
+            //TODO detach
             updatedBankAccount.Name = UpdatedName;
             updatedBankAccount.Balance = UpdatedBalance;
             updatedBankAccount.User = updatedUser;
@@ -269,6 +269,45 @@ namespace JHipsterNetSampleApplication.Test.Web.Rest {
             testBankAccount.Name.Should().Be(UpdatedName);
             testBankAccount.Balance.Should().Be(UpdatedBalance);
             testBankAccount.User.Should().Be(updatedUser);
+        }
+
+        [Fact]
+        public async Task UpdateBankAccountWithReferencedEntityToNull()
+        {
+            // Get a User to referenced
+            var user = _applicationDatabaseContext.Users.ToList()[0];
+
+            // Set the referencing field
+            _bankAccount.User = user;
+
+            // Initialize the database with a bankAccount
+            _applicationDatabaseContext.BankAccounts.Add(_bankAccount);
+            await _applicationDatabaseContext.SaveChangesAsync();
+
+            var databaseSizeBeforeUpdate = _applicationDatabaseContext.BankAccounts.Count();
+
+            // Update the bankAccount
+            var updatedBankAccount = await _applicationDatabaseContext.BankAccounts
+                .SingleOrDefaultAsync(it => it.Id == _bankAccount.Id);
+            // Disconnect from session so that the updates on updatedBankAccount are not directly saved in db
+            //TODO detach
+            updatedBankAccount.Name = UpdatedName;
+            updatedBankAccount.Balance = UpdatedBalance;
+            updatedBankAccount.User = null;
+
+            var response = await _client.PutAsync("/api/bank-accounts", TestUtil.ToJsonContent(updatedBankAccount));
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            // Validate the BankAccount in the database
+            var bankAccountList = _applicationDatabaseContext.BankAccounts
+                .Include(bankAccount => bankAccount.User)
+                .AsNoTracking()
+                .ToList();
+            bankAccountList.Count().Should().Be(databaseSizeBeforeUpdate);
+            var testBankAccount = bankAccountList[bankAccountList.Count - 1];
+            testBankAccount.Name.Should().Be(UpdatedName);
+            testBankAccount.Balance.Should().Be(UpdatedBalance);
+            testBankAccount.User.Should().BeNull();
         }
 
         [Fact]

--- a/test/JHipsterNetSampleApplication.Test/Web/Rest/LabelResourceIntTest.cs
+++ b/test/JHipsterNetSampleApplication.Test/Web/Rest/LabelResourceIntTest.cs
@@ -267,7 +267,7 @@ namespace JHipsterNetSampleApplication.Test.Web.Rest {
             // Update the label
             var updatedLabel = await _applicationDatabaseContext.Labels.SingleOrDefaultAsync(it => it.Id == _label.Id);
             // Disconnect from session so that the updates on updatedLabel are not directly saved in db
-            //TODO detach
+//TODO detach
             updatedLabel.Name = UpdatedName;
 
             var response = await _client.PutAsync("/api/labels", TestUtil.ToJsonContent(updatedLabel));

--- a/test/JHipsterNetSampleApplication.Test/Web/Rest/LabelResourceIntTest.cs
+++ b/test/JHipsterNetSampleApplication.Test/Web/Rest/LabelResourceIntTest.cs
@@ -159,6 +159,47 @@ namespace JHipsterNetSampleApplication.Test.Web.Rest {
         }
 
         [Fact]
+        public async Task DeleteLabelWithManyToManyAssociation()
+        {
+            // Due to JsonIgnore annotation on Operations property, we first create the Label
+            // This allow the operation to create the relationship
+            _applicationDatabaseContext.Labels.Add(_label);
+            await _applicationDatabaseContext.SaveChangesAsync();
+
+            // Create an Operation to test the ManyToMany association
+            var operation = new Operation {
+                Date = DateTime.Now,
+                Description = "BBBBBBBBBB",
+                Amount = new decimal(2.0)
+            };
+            operation.Labels.Add(_label);
+            _applicationDatabaseContext.Operations.Add(operation);
+            await _applicationDatabaseContext.SaveChangesAsync();
+
+            var databaseSizeBeforeDelete = _applicationDatabaseContext.Labels.Count();
+
+            var response = await _client.DeleteAsync($"/api/labels/{_label.Id}");
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            // Validate the database is empty
+            var labelList = _applicationDatabaseContext.Labels
+                .AsNoTracking()
+                .ToList();
+            labelList.Count().Should().Be(databaseSizeBeforeDelete - 1);
+
+            // Validate the Operation in the database and in particular there is no more Label referenced
+            var testOperation = await _applicationDatabaseContext.Operations
+                .Include(o => o.OperationLabels)
+                    .ThenInclude(operationLabel => operationLabel.Label)
+                .AsNoTracking()
+                .SingleOrDefaultAsync(o => o.Id == operation.Id);
+            testOperation.Date.Should().Be(operation.Date);
+            testOperation.Description.Should().Be(operation.Description);
+            testOperation.Amount.Should().Be(operation.Amount);
+            testOperation.Labels.Should().BeEmpty();
+        }
+
+        [Fact]
         public void EqualsVerifier()
         {
             TestUtil.EqualsVerifier(typeof(Label));
@@ -226,7 +267,7 @@ namespace JHipsterNetSampleApplication.Test.Web.Rest {
             // Update the label
             var updatedLabel = await _applicationDatabaseContext.Labels.SingleOrDefaultAsync(it => it.Id == _label.Id);
             // Disconnect from session so that the updates on updatedLabel are not directly saved in db
-//TODO detach
+            //TODO detach
             updatedLabel.Name = UpdatedName;
 
             var response = await _client.PutAsync("/api/labels", TestUtil.ToJsonContent(updatedLabel));

--- a/test/JHipsterNetSampleApplication.Test/Web/Rest/OperationResourceIntTest.cs
+++ b/test/JHipsterNetSampleApplication.Test/Web/Rest/OperationResourceIntTest.cs
@@ -123,6 +123,15 @@ namespace JHipsterNetSampleApplication.Test.Web.Rest {
             testOperation.Description.Should().Be(DefaultDescription);
             testOperation.Amount.Should().Be(DefaultAmount);
             testOperation.BankAccount.Should().Be(bankAccount);
+
+            // Validate the BankAccount in the database
+            var testBankAccount = await _applicationDatabaseContext.BankAccounts
+                .Include(bA => bA.Operations)
+                .AsNoTracking()
+                .SingleOrDefaultAsync(bA => bA.Id == bankAccount.Id);
+            testBankAccount.Name.Should().Be(bankAccount.Name);
+            testBankAccount.Balance.Should().Be(bankAccount.Balance);
+            testBankAccount.Operations[0].Should().Be(testOperation);
         }
 
         [Fact]
@@ -182,6 +191,83 @@ namespace JHipsterNetSampleApplication.Test.Web.Rest {
             // Validate the database is empty
             var operationList = _applicationDatabaseContext.Operations.ToList();
             operationList.Count().Should().Be(databaseSizeBeforeDelete - 1);
+        }
+
+        [Fact]
+        public async Task DeleteOperationWithExistingReferencedEntity()
+        {
+            // Create a BankAccount to referenced
+            var bankAccount = new BankAccount {
+                Name = "AAAAAAAAAA",
+                Balance = new decimal(1.0)
+            };
+            _applicationDatabaseContext.BankAccounts.Add(bankAccount);
+            await _applicationDatabaseContext.SaveChangesAsync();
+
+            // Set the referencing field
+            _operation.BankAccount = bankAccount;
+
+            // Initialize the database
+            _applicationDatabaseContext.Operations.Add(_operation);
+            await _applicationDatabaseContext.SaveChangesAsync();
+
+            var databaseSizeBeforeDelete = _applicationDatabaseContext.Operations.Count();
+
+            var response = await _client.DeleteAsync($"/api/operations/{_operation.Id}");
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            // Validate the database is empty
+            var operationList = _applicationDatabaseContext.Operations
+                .AsNoTracking()
+                .ToList();
+            operationList.Count().Should().Be(databaseSizeBeforeDelete - 1);
+
+            // Validate the BankAccount in the database and in particular there is no more Operation referenced
+            var testBankAccount = await _applicationDatabaseContext.BankAccounts
+                .Include(bA => bA.Operations)
+                .AsNoTracking()
+                .SingleOrDefaultAsync(bA => bA.Id == bankAccount.Id);
+            testBankAccount.Name.Should().Be(bankAccount.Name);
+            testBankAccount.Balance.Should().Be(bankAccount.Balance);
+            testBankAccount.Operations.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task DeleteOperationWithManyToManyAssociation()
+        {
+            // Create a Label to test the ManyToMany association
+            var label = new Label {
+                Name = "AAAAAAAAAA"
+            };
+            _applicationDatabaseContext.Labels.Add(label);
+            await _applicationDatabaseContext.SaveChangesAsync();
+
+            // Set the referencing field
+            _operation.Labels.Add(label);
+
+            // Initialize the database
+            _applicationDatabaseContext.Operations.Add(_operation);
+            await _applicationDatabaseContext.SaveChangesAsync();
+
+            var databaseSizeBeforeDelete = _applicationDatabaseContext.Operations.Count();
+
+            var response = await _client.DeleteAsync($"/api/operations/{_operation.Id}");
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            // Validate the database is empty
+            var operationList = _applicationDatabaseContext.Operations
+                .AsNoTracking()
+                .ToList();
+            operationList.Count().Should().Be(databaseSizeBeforeDelete - 1);
+
+            // Validate the Label in the database and in particular there is no more Operation referenced
+            var testLabel = await _applicationDatabaseContext.Labels
+                .Include(l => l.OperationLabels)
+                    .ThenInclude(operationLabel => operationLabel.Operation)
+                .AsNoTracking()
+                .SingleOrDefaultAsync(l => l.Id == label.Id);
+            testLabel.Name.Should().Be(label.Name);
+            testLabel.Operations.Should().BeEmpty();
         }
 
         [Fact]
@@ -271,7 +357,7 @@ namespace JHipsterNetSampleApplication.Test.Web.Rest {
             var updatedOperation =
                 await _applicationDatabaseContext.Operations.SingleOrDefaultAsync(it => it.Id == _operation.Id);
             // Disconnect from session so that the updates on updatedOperation are not directly saved in db
-//TODO detach
+            //TODO detach
             updatedOperation.Date = UpdatedDate;
             updatedOperation.Description = UpdatedDescription;
             updatedOperation.Amount = UpdatedAmount;
@@ -317,7 +403,7 @@ namespace JHipsterNetSampleApplication.Test.Web.Rest {
             var updatedOperation = await _applicationDatabaseContext.Operations
                 .SingleOrDefaultAsync(it => it.Id == _operation.Id);
             // Disconnect from session so that the updates on updatedOperation are not directly saved in db
-//TODO detach
+            //TODO detach
             updatedOperation.Date = UpdatedDate;
             updatedOperation.Description = UpdatedDescription;
             updatedOperation.Amount = UpdatedAmount;
@@ -337,11 +423,29 @@ namespace JHipsterNetSampleApplication.Test.Web.Rest {
             testOperation.Description.Should().Be(UpdatedDescription);
             testOperation.Amount.Should().Be(UpdatedAmount);
             testOperation.BankAccount.Should().Be(updatedBankAccount);
+
+            // Validate the updatedBankAccount in the database
+            var testUpdatedBankAccount = await _applicationDatabaseContext.BankAccounts
+                .Include(bA => bA.Operations)
+                .AsNoTracking()
+                .SingleOrDefaultAsync(bA => bA.Id == updatedBankAccount.Id);
+            testUpdatedBankAccount.Name.Should().Be(updatedBankAccount.Name);
+            testUpdatedBankAccount.Balance.Should().Be(updatedBankAccount.Balance);
+            testUpdatedBankAccount.Operations[0].Should().Be(testOperation);
+
+            // Validate the bankAccount in the database
+            var testBankAccount = await _applicationDatabaseContext.BankAccounts
+                .Include(bA => bA.Operations)
+                .AsNoTracking()
+                .SingleOrDefaultAsync(bA => bA.Id == bankAccount.Id);
+            testBankAccount.Name.Should().Be(bankAccount.Name);
+            testBankAccount.Balance.Should().Be(bankAccount.Balance);
+            testBankAccount.Operations.Should().BeEmpty();
         }
 
         [Fact]
         public async Task UpdateOperationWithManyToManyAssociation()
-        {   
+        {
             // Create two Labels to test the ManyToMany association
             var label = new Label {
                 Name = "AAAAAAAAAA"
@@ -366,7 +470,7 @@ namespace JHipsterNetSampleApplication.Test.Web.Rest {
             var updatedOperation = await _applicationDatabaseContext.Operations
                 .SingleOrDefaultAsync(it => it.Id == _operation.Id);
             // Disconnect from session so that the updates on updatedOperation are not directly saved in db
-//TODO detach
+            //TODO detach
             updatedOperation.Date = UpdatedDate;
             updatedOperation.Description = UpdatedDescription;
             updatedOperation.Amount = UpdatedAmount;
@@ -406,6 +510,61 @@ namespace JHipsterNetSampleApplication.Test.Web.Rest {
                 .SingleOrDefaultAsync(l => l.Id == 1);
             testLabel.Name.Should().Be(label.Name);
             testLabel.Operations.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task UpdateOperationWithReferencedEntityToNull()
+        {
+            // Create a BankAccount to referenced
+            var bankAccount = new BankAccount {
+                Name = "AAAAAAAAAA",
+                Balance = new decimal(1.0)
+            };
+            _applicationDatabaseContext.BankAccounts.Add(bankAccount);
+            await _applicationDatabaseContext.SaveChangesAsync();
+
+            // Set the referencing field
+            _operation.BankAccount = bankAccount;
+
+            // Initialize the database with an operation
+            _applicationDatabaseContext.Operations.Add(_operation);
+            await _applicationDatabaseContext.SaveChangesAsync();
+
+            var databaseSizeBeforeUpdate = _applicationDatabaseContext.Operations.Count();
+
+            // Update the operation
+            var updatedOperation = await _applicationDatabaseContext.Operations
+                .SingleOrDefaultAsync(it => it.Id == _operation.Id);
+            // Disconnect from session so that the updates on updatedOperation are not directly saved in db
+            //TODO detach
+            updatedOperation.Date = UpdatedDate;
+            updatedOperation.Description = UpdatedDescription;
+            updatedOperation.Amount = UpdatedAmount;
+            updatedOperation.BankAccount = null;
+
+            var response = await _client.PutAsync("/api/operations", TestUtil.ToJsonContent(updatedOperation));
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            // Validate the Operation in the database
+            var operationList = _applicationDatabaseContext.Operations
+                .Include(operation => operation.BankAccount)
+                .AsNoTracking()
+                .ToList();
+            operationList.Count().Should().Be(databaseSizeBeforeUpdate);
+            var testOperation = operationList[operationList.Count - 1];
+            testOperation.Date.Should().Be(UpdatedDate);
+            testOperation.Description.Should().Be(UpdatedDescription);
+            testOperation.Amount.Should().Be(UpdatedAmount);
+            testOperation.BankAccount.Should().BeNull();
+
+            // Validate the bankAccount in the database
+            var testBankAccount = await _applicationDatabaseContext.BankAccounts
+                .Include(bA => bA.Operations)
+                .AsNoTracking()
+                .SingleOrDefaultAsync(bA => bA.Id == bankAccount.Id);
+            testBankAccount.Name.Should().Be(bankAccount.Name);
+            testBankAccount.Balance.Should().Be(bankAccount.Balance);
+            testBankAccount.Operations.Should().BeEmpty();
         }
     }
 }

--- a/test/JHipsterNetSampleApplication.Test/Web/Rest/OperationResourceIntTest.cs
+++ b/test/JHipsterNetSampleApplication.Test/Web/Rest/OperationResourceIntTest.cs
@@ -357,7 +357,7 @@ namespace JHipsterNetSampleApplication.Test.Web.Rest {
             var updatedOperation =
                 await _applicationDatabaseContext.Operations.SingleOrDefaultAsync(it => it.Id == _operation.Id);
             // Disconnect from session so that the updates on updatedOperation are not directly saved in db
-            //TODO detach
+//TODO detach
             updatedOperation.Date = UpdatedDate;
             updatedOperation.Description = UpdatedDescription;
             updatedOperation.Amount = UpdatedAmount;
@@ -403,7 +403,7 @@ namespace JHipsterNetSampleApplication.Test.Web.Rest {
             var updatedOperation = await _applicationDatabaseContext.Operations
                 .SingleOrDefaultAsync(it => it.Id == _operation.Id);
             // Disconnect from session so that the updates on updatedOperation are not directly saved in db
-            //TODO detach
+//TODO detach
             updatedOperation.Date = UpdatedDate;
             updatedOperation.Description = UpdatedDescription;
             updatedOperation.Amount = UpdatedAmount;
@@ -470,7 +470,7 @@ namespace JHipsterNetSampleApplication.Test.Web.Rest {
             var updatedOperation = await _applicationDatabaseContext.Operations
                 .SingleOrDefaultAsync(it => it.Id == _operation.Id);
             // Disconnect from session so that the updates on updatedOperation are not directly saved in db
-            //TODO detach
+//TODO detach
             updatedOperation.Date = UpdatedDate;
             updatedOperation.Description = UpdatedDescription;
             updatedOperation.Amount = UpdatedAmount;


### PR DESCRIPTION
- Implementation of tests concerning the Delete operation of the ManyToOne/OneToMany association
- Implementation of tests concerning the Delete operation of the ManyToMany association (Close #5 )
- Modification and implementation of new tests concerning the Update operation of the ManyToOne/OneToMany association
- Fix a problem on the Update operation of the ManyToOne / OneToMany association. Now it is possible to
delete a relationship between 2 instances by allowing the reference to be changed to a NULL value.